### PR TITLE
Fix errors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const highlighter = new Highlight({
   html: true
 })
 
-document.body.innerHTML += highlighter.highlight("SELECT `id`, `username` FROM `users` WHERE `email` = 'test@example.com'"))
+document.body.innerHTML += highlighter.highlight("SELECT `id`, `username` FROM `users` WHERE `email` = 'test@example.com'")
 ```
 
 **Output:**

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Options may be passed to the constructor while instantiating the `Highlighter` c
 
 | Option | Value | Default | Description |
 | --- | --- | --- | --- |
-| html | `boolean` | `true` | Set to true to render HTML instead of Unicode.
+| html | `boolean` | `false` | Set to true to render HTML instead of Unicode.
 | classPrefix | `string` | `'sql-hl-'` | Prefix to prepend to classes for HTML span-tags. Is appended with entity name.
 | colors | `Object` | _See below_* | What color codes to use for Unicode rendering.
 


### PR DESCRIPTION
- Fixed the `html` default option value (was `true`).
- Removed an extra parenthesis at the end of the HTML example.
Good luck!