### PR TITLE
Fix number regex

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -65,6 +65,11 @@ describe('unicode', () => {
       .toBe("[string]'34'[clear]")
   })
 
+  it('alphanumeric', () => {
+    expect(hlUni('(f1)'))
+      .toBe('[bracket]([clear]f1[bracket])[clear]')
+  })
+
   it('functions', () => {
     expect(hlUni('COUNT(`id`)'))
       .toBe('[function]COUNT[clear][bracket]([clear][string]`id`[clear][bracket])[clear]')
@@ -125,6 +130,11 @@ describe('html', () => {
   it('numbers within strings', () => {
     expect(hlHtml("'34'"))
       .toBe("<span class=\"sql-hl-string\">'34'</span>")
+  })
+
+  it('alphanumeric', () => {
+    expect(hlHtml('(f1)'))
+      .toBe('<span class="sql-hl-bracket">(</span>f1<span class="sql-hl-bracket">)</span>')
   })
 
   it('functions', () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ const highlighters = [
   },
   {
     name: 'number',
-    regex: /(\d+(?:\.\d+)?)/g
+    regex: /((?<![a-zA-z])\d+(?:\.\d+)?)/g
   },
   {
     name: 'string',

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,7 @@ console.log(highlight("SELECT COUNT(id), `id`, `username` FROM `users` WHERE `em
 console.log(highlight('SELECT id FROM users'))
 
 console.log(highlight('WITH t1 AS (SELECT data_point FROM tablename) SELECT data_point FROM t1;'))
+console.log(highlight('SELECT f1, f20b, f3a, -1, 1, "1", 1.00 FROM t1;'))
 
 console.log(highlight('SELECT id FROM listings WHERE status = \'not available\''))
 console.log(highlight('SELECT id FROM listings WHERE status = "not available"'))


### PR DESCRIPTION
Avoid fields, tables with numbers,
**Examples:**
```sql
SELECT f1, f2, f3, -1, 1, "1", 1.00 FROM t1;
```
**Result:**
![image](https://user-images.githubusercontent.com/4933954/175380044-e6d1a6c3-b8a0-4d73-8003-c8cc3ffa1232.png)
**Result with this PR:**
![image](https://user-images.githubusercontent.com/4933954/175380142-764e5f64-5503-4a01-bb00-74e70420ab23.png)


