### PR TITLE
fix: change number regex to not use lookbehind (#106)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ const highlighters = [
   },
   {
     name: 'number',
-    regex: /((?<![a-zA-z])\d+(?:\.\d+)?)/g
+    regex: /(\b\d+(?:\.\d+)?)/g
   },
   {
     name: 'string',


### PR DESCRIPTION
Avoid crashing Safari and other browsers which do not support lookbehind in JS regular expressions (https://caniuse.com/js-regexp-lookbehind), fixes #106.