### PR TITLE
fix: add ILIKE keyword

### DIFF
--- a/lib/keywords.js
+++ b/lib/keywords.js
@@ -43,6 +43,7 @@ module.exports = [
   'FULL OUTER JOIN',
   'GROUP BY',
   'HAVING',
+  'ILIKE',
   'IN',
   'INDEX',
   'INNER JOIN',


### PR DESCRIPTION
`ILIKE` can be used in Postgres, but is missing in keywords list

https://www.postgresql.org/docs/current/functions-matching.html

<img width="789" alt="image" src="https://user-images.githubusercontent.com/6711845/230577219-4530baaf-5c83-4390-8cb4-e1c2f71a1f53.png">