### PR TITLE
fix: improve operator detection and fix unknown segment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,12 @@ const highlighters = [
 
   /(?<bracket>[()])/,
 
-  /(?<special>!=|[=%*/\-+,;:<>.])/,
+  // Arithmetic, bitwise, comparison, and compound operators as listed in
+  // https://www.w3schools.com/sql/sql_operators.asp, https://www.tutorialspoint.com/sql/sql-operators.htm,
+  // https://data-flair.training/blogs/sql-operators/.
+  // Plus a few other symbols used in SQL statements: ,;:.
+  // Operators are arranged so that multi-character operators (ex: ">=") are parsed as one operator rather than two.
+  /(?<special>\^-=|\|\*=|\+=|-=|\*=|\/=|%=|&=|>=|<=|<>|!=|!<|!>|>>|<<|[+\-*/%&|^=><]|[,;:.])/,
 
   /(?<identifier>\b\w+\b|`(?:[^`\\]|\\.)*`)/,
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,18 +33,15 @@ const highlighters = [
 
   /(?<bracket>[()])/,
 
-  // Arithmetic, bitwise, comparison, and compound operators as listed in
-  // https://www.w3schools.com/sql/sql_operators.asp, https://www.tutorialspoint.com/sql/sql-operators.htm,
-  // https://data-flair.training/blogs/sql-operators/.
-  // Plus a few other symbols used in SQL statements: ,;:.
-  // Operators are arranged so that multi-character operators (ex: ">=") are parsed as one operator rather than two.
-  /(?<special>\^-=|\|\*=|\+=|-=|\*=|\/=|%=|&=|>=|<=|<>|!=|!<|!>|>>|<<|[+\-*/%&|^=><]|[,;:.])/,
-
   /(?<identifier>\b\w+\b|`(?:[^`\\]|\\.)*`)/,
 
   /(?<whitespace>\s+)/,
 
-  /(?<unknown>\.+?)/
+  // Multi-character arithmetic, bitwise, comparison, and compound operators as listed in
+  // https://www.w3schools.com/sql/sql_operators.asp, https://www.tutorialspoint.com/sql/sql-operators.htm,
+  // https://data-flair.training/blogs/sql-operators/, plus any single character (in particular ,:;.) not matched by
+  // the above regexps.
+  /(?<special>\^-=|\|\*=|\+=|-=|\*=|\/=|%=|&=|>=|<=|<>|!=|!<|!>|>>|<<|.)/
 ]
 
 // Regex of the shape /(?<token1>...)|(?<token2>...)|.../g


### PR DESCRIPTION
This fixes the "special" segments to include some missing multi-character operators from https://www.w3schools.com/sql/sql_operators.asp and other sites.

It also expands the "special" segment to match any single character that doesn't match any of the other regexps.   That's nice because it gets rid of the need for the "unknown" segment, avoiding the problem listed in #178.

This PR contains two commits that can be merged individually.

Fixes #150, #178, refs #148.